### PR TITLE
Skip ssh test on prod

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ jobs:
 
   test_SSH:
     environment: ${{github.ref_name}}
+    if: ${{github.ref_name}} == 'pre-prod'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Pas de déploiement en SSH sur la branche prod, donc inutile des tester le connexion.