### PR TITLE
Proposition de la faq sous forme de panels

### DIFF
--- a/proPilot/imports-faq.md
+++ b/proPilot/imports-faq.md
@@ -11,18 +11,13 @@ categories:
 
 # FAQ
 
-[!badge variant="dark" icon="dot-fill" text="Question 1" margin="0 8 0 0"]
-* _Faut-il garder toutes les colonnes correspondant aux dates/mois dans le template_ ?
+
+==- Q1: _Faut-il garder toutes les colonnes correspondant aux dates/mois dans le template ?_
 Pas nécessairement, ne gardez que les colonnes que vous voulez mettre à jour afin d’éviter toute incohérence dans les imports.
-
-[!badge variant="dark" icon="dot-fill" text="Question 2" margin="0 8 0 0"]
-* _Puis-je laisser des cellules vides dans mon fichier_ ?
+==- Q2: _Puis-je laisser des cellules vides dans mon fichier ?_
 Absolument, pour les imports massifs de type "financials" : les cellules vides n’écrasent pas les contenus existants 
-
-[!badge variant="dark" icon="dot-fill" text="Question 3" margin="0 8 0 0"]
-* _Puis-je n'importer que des valeurs actuelles dans mon fichier d'import_ ?
+==- Q3: _Puis-je n'importer que des valeurs actuelles dans mon fichier d'import ?_
 Non, il est également possible d'importer des cibles territorialisées ou des valeurs initiales.
-
-[!badge variant="dark" icon="dot-fill" text="Question 4" margin="0 8 0 0"]
-* _Les décimales de mes valeurs doivent-elles être exprimées en virgules ou en points_ ?
+==- Q4: _Les décimales de mes valeurs doivent-elles être exprimées en virgules ou en points ?_
 Elles doivent être exprimées en virgules de préférence
+==-


### PR DESCRIPTION
Je propose une version de la FAQ sous la forme de panels cliquables pour être déroulés:
- [version actuelle](https://retype.4p-analyse.fr/centre-aide-pilote/pre-prod/propilot/imports-faq/)
- [ma proposition](https://retype.4p-analyse.fr/centre-aide-pilote/faq-panels/propilot/imports-faq/)

Je pense que ce sera plus lisible quand on aura plus de questions encore par rapport à la version actuelle. 

Evolutions:
- on pourra créer plusieurs blocs déroulants (et non un unique) à l'avenir pour grouper les questions par thèmes pour les organiser
- et @cecilaki / @AdrienLaville  / @JBcaut vous pouvez rajouter des [badges](https://retype.com/components/badge/#variants) ou [éléments d'UI](https://retype.com/components/) pour rendre ça plus engageant, comme dans la version actuelle. J'ai uniquement donné mon avis sur le fonctionnel ici aha 